### PR TITLE
Add autoscaling, health checks, & minor app changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ terraform/loadbalancing/main.tf
 *.tfstate
 *.tfstate.backup
 *.tfvars
+.env

--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ _An application for visualizing FPV quadcopter telemetry data logged by OpenTx/E
 * :dart: Testing
 
 _Development updates May 2022:_
+* Configured auto-scaling policies and container health checks
 * Deployed Datadog Agent container to monitor service metrics
 * Added a Demo button to allow users to preview the application
 
 _Development updates April 2022:_
-* Deployed infrastructure as code with branch-dependent Actions workflow* 
+* Deployed infrastructure as code with branch-dependent Actions workflow
 * Added ability for user to demo the app using a sample telemetry log
 
 _Development update March 2022:_

--- a/app/app.py
+++ b/app/app.py
@@ -84,7 +84,7 @@ Choose from metric or Imperial units.
 """
 
 update_markdown = """
-_Latest update: Apr 30, 2022_
+_Latest update: May 22, 2022_
 """
 
 if 'demomode' not in st.session_state:

--- a/app/app.py
+++ b/app/app.py
@@ -31,7 +31,7 @@ def display_flight(data, unit, alt, spd):
     col4.metric('Capacity Used', mt.get_capacity_used(data['Capa(mAh)']))
     col5.metric('Transmitter Power', mt.get_tx_power(data['TPWR(mW)']))
 
-    st.subheader('Flight Map')
+    st.subheader('3D Flight Map')
     st.markdown('_Drag to pan. Hold `SHIFT` and drag to rotate. Scroll to zoom._')
     flight_map = mp.create_flight_map(data)
     st.pydeck_chart(flight_map)
@@ -87,7 +87,6 @@ update_markdown = """
 _Latest update: Apr 30, 2022_
 """
 
-demo.get_demo_telemetry()
 if 'demomode' not in st.session_state:
     st.session_state.demomode = False
 
@@ -103,6 +102,7 @@ st.markdown(subtitle_markdown)
 st.sidebar.title('Skyboy Utilities')
 demo_button = st.sidebar.button("Demo Skyboy")
 if demo_button:
+    demo.get_demo_telemetry()
     st.session_state.demomode = True
 uploaded_file = st.sidebar.file_uploader('Upload a telemetry log:', type=['csv'])
 

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -68,6 +68,7 @@ Pympler==1.0.1
 pyparsing==3.0.7
 pyrsistent==0.18.1
 python-dateutil==2.8.2
+python-dotenv==0.20.0
 pytz==2021.3
 pytz-deprecation-shim==0.1.0.post0
 pyzmq==22.3.0

--- a/terraform/autoscaling/main.tf
+++ b/terraform/autoscaling/main.tf
@@ -1,0 +1,45 @@
+# autoscaling/main.tf
+
+resource "aws_appautoscaling_target" "skyboy_scaling_target" {
+  max_capacity       = 4
+  min_capacity       = 1
+  resource_id        = "service/${var.cluster_name}/${var.service_name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "skyboy_cpu_policy" {
+  name               = "cpu-autoscaling"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.skyboy_scaling_target.resource_id
+  scalable_dimension = aws_appautoscaling_target.skyboy_scaling_target.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.skyboy_scaling_target.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    target_value       = 80
+    scale_in_cooldown  = 60
+    scale_out_cooldown = 60
+
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+  }
+}
+
+resource "aws_appautoscaling_policy" "skyboy_memory_policy" {
+  name               = "memory-autoscaling"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.skyboy_scaling_target.resource_id
+  scalable_dimension = aws_appautoscaling_target.skyboy_scaling_target.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.skyboy_scaling_target.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    target_value       = 80
+    scale_in_cooldown  = 60
+    scale_out_cooldown = 60
+
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageMemoryUtilization"
+    }
+  }
+}

--- a/terraform/autoscaling/variables.tf
+++ b/terraform/autoscaling/variables.tf
@@ -1,0 +1,9 @@
+# autoscaling/variables.tf
+
+variable "cluster_name" {
+  type = string
+}
+
+variable "service_name" {
+  type = string
+}

--- a/terraform/containers/main.tf
+++ b/terraform/containers/main.tf
@@ -32,6 +32,10 @@ resource "aws_ecs_service" "skyboy_service" {
     container_name   = var.container_name
     container_port   = var.container_port
   }
+
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
 }
 
 resource "aws_ecs_task_definition" "skyboy_task" {

--- a/terraform/containers/outputs.tf
+++ b/terraform/containers/outputs.tf
@@ -1,0 +1,9 @@
+# containers/outputs.tf
+
+output "cluster_name" {
+  value = aws_ecs_cluster.skyboy_cluster.name
+}
+
+output "service_name" {
+  value = aws_ecs_service.skyboy_service.name
+}

--- a/terraform/containers/task-definitions/skyboy.template
+++ b/terraform/containers/task-definitions/skyboy.template
@@ -20,6 +20,14 @@
         "awslogs-stream-prefix": "ecs"
       }
     },
+    "healthCheck": {
+      "retries": 3,
+      "command": [
+        "CMD-SHELL", "curl -f http://127.0.0.1:8501/ || exit 1"
+      ],
+      "timeout": 5,
+      "interval": 30
+    },
     "secrets": [
       {
         "name": "S3_USER_ID",
@@ -35,7 +43,7 @@
     "name": "datadog-agent",
     "image": "public.ecr.aws/datadog/agent:latest",
     "cpu": 10,
-    "essential": true,
+    "essential": false,
     "environment": [
       {
         "name": "DD_API_KEY",

--- a/terraform/iam/main.tf
+++ b/terraform/iam/main.tf
@@ -16,11 +16,11 @@ data "aws_iam_policy_document" "datadog_aws_integration_assume_role" {
     actions = ["sts:AssumeRole"]
 
     principals {
-      type = "AWS"
+      type        = "AWS"
       identifiers = ["arn:aws:iam::464622532012:root"]
     }
     condition {
-      test = "StringEquals"
+      test     = "StringEquals"
       variable = "sts:ExternalId"
 
       values = [var.datadog_aws_integration_external_id]
@@ -133,8 +133,8 @@ resource "aws_iam_role" "ecs_task_role" {
 }
 
 resource "aws_iam_role" "datadog_aws_integration" {
-  name = "DatadogAWSIntegrationRole"
-  description = "Role for Datadog AWS Integration"
+  name               = "DatadogAWSIntegrationRole"
+  description        = "Role for Datadog AWS Integration"
   assume_role_policy = data.aws_iam_policy_document.datadog_aws_integration_assume_role.json
 }
 
@@ -145,7 +145,7 @@ resource "aws_iam_policy" "ecs_task_policy" {
 }
 
 resource "aws_iam_policy" "datadog_aws_integration" {
-  name = "DatadogAWSIntegrationPolicy"
+  name   = "DatadogAWSIntegrationPolicy"
   policy = data.aws_iam_policy_document.datadog_aws_integration.json
 }
 
@@ -155,6 +155,6 @@ resource "aws_iam_role_policy_attachment" "ecs_task_policy_attachment" {
 }
 
 resource "aws_iam_role_policy_attachment" "datadog_aws_integration" {
-  role = aws_iam_role.datadog_aws_integration.name
+  role       = aws_iam_role.datadog_aws_integration.name
   policy_arn = aws_iam_policy.datadog_aws_integration.arn
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -35,3 +35,9 @@ module "containers" {
   target_group_arn    = module.loadbalancing.lb_target_group_arn
   task_role_arn       = module.iam.ecs_task_role_arn
 }
+
+module "autoscaling" {
+  source       = "./autoscaling"
+  cluster_name = module.containers.cluster_name
+  service_name = module.containers.service_name
+}


### PR DESCRIPTION
This update:

- adds ECS autoscaling policies to the Terraform configuration;
- adds a container health check to the container definition template;
- changes the dem file download behavior to only be triggered when the Demo button is clicked.